### PR TITLE
fix(infra): add lambda:ListVersionsByFunction to CI terraform role

### DIFF
--- a/infra/terraform/modules/greenspace_stack/iam.tf
+++ b/infra/terraform/modules/greenspace_stack/iam.tf
@@ -483,6 +483,7 @@ data "aws_iam_policy_document" "ci_terraform_resources" {
       "lambda:GetFunctionUrlConfig",
       "lambda:UpdateFunctionUrlConfig",
       "lambda:DeleteFunctionUrlConfig",
+      "lambda:ListVersionsByFunction",
     ]
     resources = [
       "arn:aws:lambda:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:function:${local.naming_prefix}-*",


### PR DESCRIPTION
## Summary

- Adds `lambda:ListVersionsByFunction` to the CI terraform IAM role's `LambdaManage` policy statement
- The AWS Terraform provider requires this permission when refreshing `aws_lambda_function` resource state during `terraform plan`
- Without it, the staging plan job fails with `AccessDeniedException`

Closes #81

## Bootstrap Note

This is a chicken-and-egg fix: the CI terraform role's own policy is managed by Terraform, but the plan fails due to the missing permission. The permission must be manually added to the role in the AWS Console first, then this PR can be merged to codify the fix permanently.

## Test plan

- [ ] Manually add `lambda:ListVersionsByFunction` to the `terraform-resources` inline policy on the `greenspace-staging-2026-ci-terraform` role in AWS Console
- [ ] Re-run the staging Terraform plan workflow and verify it succeeds
- [ ] Merge this PR to codify the fix

Generated with [Claude Code](https://claude.com/claude-code)