### PR TITLE
fix(api): add require shim to ESM bundle for pg compatibility

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "bundle": "esbuild src/lambda.ts --bundle --platform=node --target=node20 --format=esm --outfile=dist/lambda/index.mjs --external:pg-native --external:@aws-sdk/*",
+    "bundle": "esbuild src/lambda.ts --bundle --platform=node --target=node20 --format=esm --outfile=dist/lambda/index.mjs --external:pg-native --external:@aws-sdk/* --banner:js=\"import{createRequire}from'module';const require=createRequire(import.meta.url);\"",
     "db:setup": "tsx src/db/setup.ts",
     "dev": "tsx watch src/dev-server.ts",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

  - Adds a `createRequire` banner to the esbuild bundle command so that `pg`'s CommonJS `require()` calls for Node.js built-ins (`events`, `net`,
   `tls`, etc.) work in the ESM Lambda runtime
  - Without this, the Lambda crashes on init with `Dynamic require of "events" is not supported`, returning 502 on all requests

  ## Test plan

  - [ ] Run `npm run bundle --workspace=@greenspace/api` locally and verify the banner appears at the top of `dist/lambda/index.mjs`
  - [ ] Deploy to staging and verify the `/health` endpoint returns 200