### PR TITLE
fix(infra): grant Lambda role KMS decrypt for secrets access

### DIFF
--- a/infra/terraform/modules/greenspace_stack/iam.tf
+++ b/infra/terraform/modules/greenspace_stack/iam.tf
@@ -41,6 +41,16 @@ data "aws_iam_policy_document" "api_secrets" {
       "arn:aws:secretsmanager:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:secret:${local.naming_prefix}-*",
     ]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [
+      aws_kms_key.data.arn,
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "api_secrets" {


### PR DESCRIPTION
## Summary

  - Adds `kms:Decrypt` permission on the data KMS key to the API Lambda role's `api_secrets` policy
  - The DB credentials secret is encrypted with this key, so `secretsmanager:GetSecretValue` alone is insufficient — the role also needs KMS decrypt access
  - Without this, the Lambda fails at runtime with `AccessDeniedException: Access to KMS is not allowed`

  Closes #47

  ## Test plan

  - [ ] Apply Terraform (or manually add `kms:Decrypt` to the Lambda role in AWS Console)
  - [ ] Deploy the API and verify `/health` returns 200