### PR TITLE
docs: update READMEs and add architecture document

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,21 @@ Greenspace is the UN17 rooftop greenhouse registration platform for the 2026 sea
 
 Primary product specification:
 - [Greenspace 2026 Spec](docs/specs/greenspace-2026-spec.md)
+- [Architecture Overview](docs/architecture.md)
 
 ## Repository Layout
 
-- `apps/web` - Next.js frontend for public and admin UI.
-- `apps/api` - API services (registration, admin operations, email workflows).
-- `packages/shared` - shared types, validation schemas, and i18n/domain constants.
-- `infra/terraform` - AWS infrastructure as code (staging and production).
-- `docs` - product specs, ADRs, API contracts, and data model docs.
+- [`apps/web`](apps/web/) - Next.js 15 frontend for public and admin UI.
+- [`apps/api`](apps/api/) - API services (registration, admin operations, email workflows).
+- [`packages/shared`](packages/shared/) - Shared types, validation schemas, and i18n/domain constants.
+- [`infra/`](infra/) - AWS infrastructure as code.
+  - [`infra/terraform`](infra/terraform/) - Terraform modules and environment stacks.
+  - [`infra/terraform/modules/greenspace_stack`](infra/terraform/modules/greenspace_stack/) - Shared AWS resource module.
+- [`docs/`](docs/) - Product specs, architecture, ADRs, API contracts, and data model docs.
+  - [`docs/architecture.md`](docs/architecture.md) - System architecture with diagrams.
+  - [`docs/api/openapi.yaml`](docs/api/openapi.yaml) - OpenAPI 3.1 contract.
+  - [`docs/data/schema.md`](docs/data/schema.md) - Data contract and invariants.
+  - [`docs/adr/`](docs/adr/) - Architecture Decision Records.
 - `.github` - CI workflows and contribution templates.
 
 ## Local Development

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,15 +1,53 @@
 # apps/api
 
-Backend API application.
+Backend API application (Node.js/TypeScript).
 
-Responsibilities:
+## Responsibilities
+
 - Public endpoints for status, availability, registration, waitlist.
 - Admin endpoints for authentication and management operations.
 - Audit event recording and outbound email orchestration.
 
 Must not contain:
-- frontend rendering code
-- infrastructure provisioning logic
+- Frontend rendering code.
+- Infrastructure provisioning logic.
+
+## Tech Stack
+
+- **Runtime:** Node.js (TypeScript)
+- **Database:** PostgreSQL 16 via [Kysely](https://kysely.dev/)
+- **Auth:** Argon2id password hashing, HttpOnly session cookies
+- **Testing:** Vitest
+- **Linting:** ESLint
+
+## Source Structure
+
+```
+src/
+├── db/
+│   ├── connection.ts        Database connection factory
+│   ├── index.ts             DB module entry point
+│   ├── migrate.ts           Migration runner
+│   ├── migrations/          Kysely migration files
+│   ├── schema.test.ts       Schema validation tests
+│   ├── seed.ts              Seed data (greenhouses, boxes, admins)
+│   ├── seed.test.ts         Seed validation tests
+│   ├── setup.ts             Combined migrate + seed entry point
+│   └── types.ts             Database table type definitions
+├── lib/
+│   ├── errors.ts            Typed API error classes
+│   ├── password.ts          Argon2id hashing and verification
+│   └── session.ts           Session token generation
+├── middleware/
+│   └── auth.ts              Admin session authentication middleware
+├── routes/
+│   ├── admin/auth.ts        Admin login and password change
+│   ├── health.ts            Health check endpoint
+│   └── public.ts            Public status and box endpoints
+├── router.ts                Route registration
+├── dev-server.ts            Local development HTTP server
+└── index.ts                 Application entry point
+```
 
 ## Database
 
@@ -19,7 +57,7 @@ Uses [Kysely](https://kysely.dev/) as a type-safe query builder with PostgreSQL.
 
 The schema is managed through Kysely migrations in `src/db/migrations/`. The initial migration creates all 10 core tables:
 
-- `greenhouses` - Greenhouse records (Kronen, Søen)
+- `greenhouses` - Greenhouse records (Kronen, Soen)
 - `planter_boxes` - 29 named planter boxes with state tracking
 - `admins` - Admin accounts
 - `admin_credentials` - Hashed admin passwords
@@ -41,16 +79,18 @@ The schema is managed through Kysely migrations in `src/db/migrations/`. The ini
 ### Seed data
 
 The seed module (`src/db/seed.ts`) populates:
-- 2 greenhouses (Kronen, Søen)
+- 2 greenhouses (Kronen, Soen)
 - 29 planter boxes with spec naming and numbering
 - Default opening datetime (2026-04-01 10:00 Europe/Copenhagen)
 - 2 initial admin accounts (passwords must be hashed at seed time)
 
-### Running migrations
+## Scripts
 
-```typescript
-import { createDatabase, migrateToLatest } from "./db/index.js";
-
-const db = createDatabase({ host, port, database, user, password });
-await migrateToLatest(db);
+```bash
+npm run dev        # Start dev server (port 3001)
+npm run build      # Compile TypeScript
+npm run test       # Run Vitest tests
+npm run lint       # Run ESLint
+npm run typecheck  # Type checking
+npm run db:setup   # Run migrations + seed (requires DB_PASSWORD)
 ```

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,12 +1,57 @@
 # apps/web
 
-Frontend application (planned Next.js).
+Next.js 15 frontend application (React 19, App Router).
 
-Responsibilities:
-- Public registration experience.
+## Responsibilities
+
+- Public registration experience (greenhouse maps, box selection, registration form).
 - Admin dashboard experience.
-- Localization (`da`, `en`) and UI-level validation.
+- Bilingual UI (`da`, `en`) with browser-default detection and manual switching.
+- Pre-open mode (blocks registration before configured opening datetime).
 
 Must not contain:
-- direct database access
-- AWS provisioning logic
+- Direct database access.
+- AWS provisioning logic.
+
+## Tech Stack
+
+- **Framework:** Next.js 15 (App Router)
+- **React:** 19
+- **Styling:** Inline styles (no CSS framework)
+- **Testing:** Vitest
+- **Linting:** ESLint
+
+## Source Structure
+
+```
+src/
+├── app/
+│   ├── layout.tsx           Root layout with LanguageProvider
+│   ├── page.tsx             Main page (pre-open / landing / map routing)
+│   └── page.test.tsx        Integration tests
+├── components/
+│   ├── BoxCard.tsx           Individual planter box card with state badge
+│   ├── BoxStateLegend.tsx    Color legend for box states
+│   ├── boxStateColors.ts    Shared color constants for box states
+│   ├── GreenhouseCard.tsx    Greenhouse summary card (clickable)
+│   ├── GreenhouseMap.tsx     Responsive CSS grid of box cards
+│   ├── GreenhouseMapPage.tsx Full greenhouse map view
+│   ├── LandingPage.tsx       Greenhouse overview with cards
+│   ├── LanguageSelector.tsx  da/en language toggle
+│   └── PreOpenPage.tsx       Pre-registration info page
+├── i18n/
+│   ├── LanguageProvider.tsx  React context for language state
+│   └── translations.ts      Danish and English translation strings
+└── utils/
+    └── opening.ts            Opening datetime comparison helper
+```
+
+## Scripts
+
+```bash
+npm run dev        # Start Next.js dev server (port 3000)
+npm run build      # Production build
+npm run test       # Run Vitest tests
+npm run lint       # Run ESLint
+npm run typecheck  # TypeScript type checking
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# docs
+
+Project documentation for Greenspace 2026.
+
+## Contents
+
+| Path | Description |
+|------|-------------|
+| [specs/greenspace-2026-spec.md](specs/greenspace-2026-spec.md) | Full product and technical specification |
+| [architecture.md](architecture.md) | System architecture overview with diagrams |
+| [api/openapi.yaml](api/openapi.yaml) | OpenAPI 3.1 contract for all public and admin endpoints |
+| [data/schema.md](data/schema.md) | Data contract, entity list, and critical invariants |
+| [adr/](adr/) | Architecture Decision Records |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,370 @@
+# Greenspace 2026 Architecture
+
+## System Overview
+
+Greenspace is a bilingual (Danish/English) registration platform that allows UN17 residents to register for rooftop planter boxes across two greenhouses. The system serves public users (no authentication) and admin users (email/password authentication).
+
+```mermaid
+graph TB
+    subgraph Users
+        PU[Public Users]
+        AU[Admin Users]
+    end
+
+    subgraph Frontend
+        WEB[Next.js 15 App<br/>React 19 / App Router]
+    end
+
+    subgraph Backend
+        API[API Server<br/>Node.js / TypeScript]
+    end
+
+    subgraph AWS
+        SES[SES<br/>Email Delivery]
+        RDS[(RDS PostgreSQL 16)]
+        SM[Secrets Manager]
+    end
+
+    PU --> WEB
+    AU --> WEB
+    WEB -->|REST API| API
+    API --> RDS
+    API --> SES
+    API --> SM
+```
+
+## Frontend Architecture
+
+The frontend is a Next.js 15 application using the App Router with React 19. It uses inline styles and a custom i18n system based on React context.
+
+```mermaid
+graph TB
+    subgraph "Next.js App Router"
+        LAYOUT[layout.tsx<br/>LanguageProvider]
+        PAGE[page.tsx<br/>View Router]
+    end
+
+    subgraph Views
+        PRE[PreOpenPage<br/>Info + countdown]
+        LAND[LandingPage<br/>Greenhouse cards]
+        MAP[GreenhouseMapPage<br/>Box grid + legend]
+    end
+
+    subgraph "Shared Components"
+        GC[GreenhouseCard]
+        BC[BoxCard]
+        BSL[BoxStateLegend]
+        GM[GreenhouseMap]
+        LS[LanguageSelector]
+    end
+
+    subgraph "i18n"
+        LP[LanguageProvider<br/>React Context]
+        TR[translations.ts<br/>da / en]
+    end
+
+    LAYOUT --> PAGE
+    PAGE -->|preOpen| PRE
+    PAGE -->|open, no selection| LAND
+    PAGE -->|greenhouse selected| MAP
+    LAND --> GC
+    MAP --> GM
+    MAP --> BSL
+    GM --> BC
+    LP --> TR
+```
+
+### View Routing
+
+The app uses state-driven view switching (not URL routing):
+
+1. **Pre-open mode** — When current time < opening datetime, show `PreOpenPage`.
+2. **Landing** — After opening, show `LandingPage` with greenhouse summary cards.
+3. **Map view** — When a greenhouse is selected, show `GreenhouseMapPage` with box grid.
+
+### i18n
+
+Language detection follows this priority:
+1. Browser locale (`navigator.language`)
+2. Manual user selection via `LanguageSelector`
+
+The `LanguageProvider` React context makes the current language and `t()` translation function available to all components. Translation strings are defined in `translations.ts` with key contracts in `@greenspace/shared`.
+
+## Backend Architecture
+
+The API is a Node.js/TypeScript application using Kysely as a type-safe PostgreSQL query builder.
+
+```mermaid
+graph TB
+    subgraph "HTTP Layer"
+        ROUTER[router.ts<br/>Route Registration]
+    end
+
+    subgraph "Routes"
+        PUB[public.ts<br/>Status / Boxes / Register / Waitlist]
+        AUTH[admin/auth.ts<br/>Login / Change Password]
+        HEALTH[health.ts<br/>Health Check]
+    end
+
+    subgraph "Middleware"
+        AUTHMW[auth.ts<br/>Session Validation]
+    end
+
+    subgraph "Libraries"
+        PWD[password.ts<br/>Argon2id]
+        SESS[session.ts<br/>Token Generation]
+        ERR[errors.ts<br/>Typed Errors]
+    end
+
+    subgraph "Database Layer"
+        CONN[connection.ts<br/>Kysely Pool]
+        MIG[migrations/<br/>Schema DDL]
+        SEED[seed.ts<br/>Initial Data]
+    end
+
+    ROUTER --> PUB
+    ROUTER --> AUTH
+    ROUTER --> HEALTH
+    AUTH --> AUTHMW
+    AUTH --> PWD
+    AUTH --> SESS
+    PUB --> CONN
+    AUTH --> CONN
+    CONN --> MIG
+    CONN --> SEED
+```
+
+### API Surface
+
+| Method | Path                          | Auth   | Description                        |
+|--------|-------------------------------|--------|------------------------------------|
+| GET    | `/public/status`              | None   | Registration open/closed status    |
+| GET    | `/public/greenhouses`         | None   | Greenhouse summary counts          |
+| GET    | `/public/boxes`               | None   | Public-safe box states             |
+| POST   | `/public/register`            | None   | Register for a planter box         |
+| POST   | `/public/waitlist`            | None   | Join waitlist                      |
+| POST   | `/admin/auth/login`           | None   | Admin login                        |
+| POST   | `/admin/auth/change-password` | Admin  | Change own password                |
+| GET    | `/admin/registrations`        | Admin  | List all registrations             |
+| POST   | `/admin/registrations`        | Admin  | Create override reservation        |
+| POST   | `/admin/registrations/move`   | Admin  | Move registration between boxes    |
+| POST   | `/admin/registrations/remove` | Admin  | Remove registration                |
+| POST   | `/admin/waitlist/assign`      | Admin  | Assign waitlist entry to box       |
+| PATCH  | `/admin/settings/opening-time`| Admin  | Update opening datetime            |
+| POST   | `/admin/admins`               | Admin  | Create admin account               |
+| DELETE | `/admin/admins/:id`           | Admin  | Delete admin account               |
+| GET    | `/admin/audit`                | Admin  | Retrieve audit timeline            |
+| GET    | `/health`                     | None   | Health check                       |
+
+## Database Architecture
+
+PostgreSQL 16 with 10 core tables. Schema is managed via Kysely migrations.
+
+```mermaid
+erDiagram
+    greenhouses ||--o{ planter_boxes : contains
+    planter_boxes ||--o| registrations : "occupied by"
+    admins ||--|| admin_credentials : "has credentials"
+    admins ||--o{ sessions : "has sessions"
+
+    greenhouses {
+        uuid id PK
+        text name
+    }
+
+    planter_boxes {
+        int id PK
+        text name
+        uuid greenhouse_id FK
+        text state "available|occupied|reserved"
+        text reserved_label
+    }
+
+    registrations {
+        uuid id PK
+        int box_id FK
+        text name
+        text email
+        text apartment_key UK
+        text status "active|switched|removed"
+    }
+
+    waitlist_entries {
+        uuid id PK
+        text name
+        text email
+        text apartment_key
+        text status "waiting|assigned|cancelled"
+    }
+
+    admins {
+        uuid id PK
+        text email UK
+    }
+
+    admin_credentials {
+        uuid admin_id PK,FK
+        text password_hash
+    }
+
+    sessions {
+        uuid id PK
+        uuid admin_id FK
+        timestamp expires_at
+    }
+
+    system_settings {
+        uuid id PK
+        timestamp opening_datetime
+    }
+
+    emails {
+        uuid id PK
+        text recipient_email
+        text status "pending|sent|failed"
+        boolean edited_before_send
+    }
+
+    audit_events {
+        uuid id PK
+        timestamp timestamp
+        text actor_type "public|admin|system"
+        text action
+        jsonb before
+        jsonb after
+    }
+```
+
+### Key Constraints
+
+- **One active registration per apartment** — Partial unique index on `apartment_key` where `status = 'active'`.
+- **One active occupant per box** — Partial unique index on `box_id` where `status = 'active'`.
+- **Immutable audit trail** — Database trigger prevents UPDATE/DELETE on `audit_events`.
+- **Box states** — Enum constraint: `available`, `occupied`, `reserved`.
+- **FIFO waitlist** — Ordered by `created_at`; duplicate apartment preserves earliest timestamp.
+
+## Infrastructure Architecture
+
+All AWS infrastructure is managed via Terraform with isolated staging and production environments.
+
+```mermaid
+graph TB
+    subgraph "GitHub"
+        REPO[Repository<br/>ammonlarson/greenspace]
+        CI[CI Workflow<br/>ci.yml]
+        TF_WF[Terraform Workflow<br/>terraform.yml]
+    end
+
+    subgraph "AWS (eu-north-1)"
+        subgraph "Networking"
+            VPC[VPC]
+            PUB_SUB[Public Subnets]
+            PRIV_SUB[Private Subnets]
+            IGW[Internet Gateway]
+            NAT[NAT Gateway]
+        end
+
+        subgraph "Compute"
+            RDS[(RDS PostgreSQL)]
+        end
+
+        subgraph "Email"
+            SES_ID[SES Domain Identity]
+            SES_DKIM[DKIM Signing]
+            SES_CS[Configuration Set]
+        end
+
+        subgraph "DNS"
+            R53[Route 53<br/>Hosted Zone]
+        end
+
+        subgraph "Security"
+            IAM_API[API Runtime Role]
+            IAM_CI[CI Deploy Role]
+            IAM_TF[CI Terraform Role]
+            KMS[KMS Encryption Key]
+            SECRETS[Secrets Manager]
+        end
+
+        subgraph "Monitoring"
+            CW[CloudWatch<br/>Log Groups]
+        end
+
+        subgraph "State Backend"
+            S3[S3 Bucket<br/>tfstate]
+            DDB[DynamoDB<br/>Lock Table]
+        end
+    end
+
+    REPO --> CI
+    REPO --> TF_WF
+    TF_WF -->|OIDC| IAM_TF
+    IAM_TF --> VPC
+    IAM_TF --> RDS
+    IAM_TF --> SES_ID
+    IAM_TF --> R53
+    VPC --> PUB_SUB
+    VPC --> PRIV_SUB
+    PUB_SUB --> IGW
+    PRIV_SUB --> NAT
+    R53 --> SES_ID
+    SES_ID --> SES_DKIM
+```
+
+### Environments
+
+| Environment | Domain                | VPC CIDR       | RDS Instance    |
+|-------------|----------------------|----------------|-----------------|
+| staging     | `staging.un17hub.com`| `10.0.0.0/16`  | `db.t4g.micro`  |
+| prod        | `un17hub.com`        | `10.1.0.0/16`  | `db.t4g.small`  |
+
+### Terraform Module Structure
+
+```
+infra/terraform/
+├── bootstrap/                 One-time state backend setup
+│   ├── main.tf
+│   └── variables.tf
+├── environments/
+│   ├── staging/main.tf        Staging stack configuration
+│   └── prod/main.tf           Production stack + subdomain delegation
+└── modules/
+    └── greenspace_stack/      Shared module for all AWS resources
+        ├── main.tf            Naming prefix, provider config
+        ├── networking.tf      VPC, subnets, gateways
+        ├── iam.tf             IAM roles and policies
+        ├── database.tf        RDS, Secrets Manager
+        ├── ses.tf             SES identity, DKIM, config set
+        ├── dns.tf             Route 53 zone and records
+        ├── monitoring.tf      CloudWatch, KMS
+        ├── variables.tf       Input variables
+        ├── outputs.tf         Module outputs
+        └── iam.tftest.hcl     Least-privilege validation tests
+```
+
+### CI/CD Pipeline
+
+```mermaid
+graph LR
+    PR[Pull Request] -->|trigger| CI_CHECK[CI Check<br/>lint + test + build]
+    PR -->|infra changes| TF_PLAN[Terraform Plan<br/>staging + prod]
+
+    MERGE[Merge to main] -->|trigger| CI_MAIN[CI Check]
+    MERGE -->|infra changes| TF_STAGING[Apply Staging]
+    TF_STAGING -->|success| TF_PROD[Apply Prod<br/>manual approval]
+```
+
+- **CI** runs on every PR: lint, test, build for all workspaces; `terraform fmt` + `terraform validate`.
+- **Terraform** runs when `infra/terraform/**` changes: plan on PRs, apply on merge to main.
+- **Production apply** requires manual approval via GitHub environment protection rules.
+- **AWS auth** uses GitHub OIDC role assumption (no long-lived keys).
+
+## Shared Package
+
+The `@greenspace/shared` package contains code used by both frontend and backend:
+
+- **Domain constants** — Greenhouse names, 29-box catalog, opening datetime, email config.
+- **Types** — Interfaces for all entities (`PlanterBoxPublic`, `Registration`, etc.).
+- **Validators** — Address, email, name validation with typed results.
+- **i18n contracts** — Translation key definitions and language labels.
+- **Enums** — Box states, registration statuses, audit actions.

--- a/infra/terraform/modules/greenspace_stack/README.md
+++ b/infra/terraform/modules/greenspace_stack/README.md
@@ -1,14 +1,18 @@
 # greenspace_stack module
 
-Top-level module placeholder for Greenspace AWS resources.
+Composable Terraform module for all Greenspace AWS resources. Used by both
+the staging and production environment stacks.
 
-This module will eventually compose:
-- API Gateway + Lambda
-- RDS/Aurora
-- SES configuration
-- S3 assets bucket(s)
-- IAM roles/policies
-- DNS/TLS integration points
+## Resources provisioned
+
+| File             | Resources                                                  |
+|------------------|------------------------------------------------------------|
+| `networking.tf`  | VPC, public/private subnets, internet gateway, NAT gateway |
+| `iam.tf`         | API runtime role, CI deploy role, CI Terraform role        |
+| `database.tf`    | RDS PostgreSQL instance, subnet group, Secrets Manager     |
+| `ses.tf`         | SES domain identity, DKIM, configuration set               |
+| `dns.tf`         | Route 53 hosted zone, SES verification/DKIM DNS records    |
+| `monitoring.tf`  | CloudWatch log groups, KMS encryption key                  |
 
 ## Least-privilege IAM
 
@@ -43,3 +47,22 @@ are managed by Terraform. After the first `terraform apply`:
    nameservers.
 3. SES will verify the domain and enable DKIM signing automatically once DNS
    propagates.
+
+## Key variables
+
+| Variable                      | Description                                          |
+|-------------------------------|------------------------------------------------------|
+| `environment`                 | Deployment environment name (staging, prod)          |
+| `vpc_cidr`                    | CIDR block for the VPC                               |
+| `ses_sender_domain`           | Domain for SES identity and Route 53 zone            |
+| `ses_reply_to_email`          | Default Reply-To (defaults to `elise7284@gmail.com`) |
+| `cloudfront_distribution_arns`| CloudFront ARNs for CI invalidation permissions      |
+| `db_instance_class`           | RDS instance class                                   |
+
+See `variables.tf` for the full list with descriptions and defaults.
+
+## Testing
+
+```bash
+terraform test  # Runs iam.tftest.hcl (least-privilege validation)
+```

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,9 +1,45 @@
 # packages/shared
 
-Shared code used by `apps/web` and `apps/api`.
+Shared TypeScript code used by `apps/web` and `apps/api`.
 
-Planned contents:
-- domain constants (greenhouses, boxes, status enums)
-- validation schemas
-- shared TypeScript types
-- i18n keys and message contracts
+## Contents
+
+- **Enums** (`enums.ts`) — Box states, registration statuses, waitlist statuses, actor types, languages, audit actions, email statuses.
+- **Constants** (`constants.ts`) — Greenhouse names, 29-box catalog with global numbering, opening datetime, email sender/reply-to, organizer contacts, address eligibility rules.
+- **Types** (`types.ts`) — Interfaces for all domain entities: `PlanterBoxPublic`, `GreenhouseSummary`, `Registration`, `WaitlistEntry`, `AuditEvent`, form inputs, etc.
+- **Validators** (`validators.ts`) — Address validation (street, house number, floor/door rules), email, name, and box ID validation with typed results.
+- **i18n** (`i18n.ts`) — Translation key contracts and language display labels (`Dansk`, `English`).
+
+## Source Structure
+
+```
+src/
+├── constants.ts        Domain constants and box catalog
+├── constants.test.ts   Constant validation tests
+├── enums.ts            Status and type enums
+├── i18n.ts             i18n key contracts and language labels
+├── index.ts            Package entry point (re-exports all)
+├── index.test.ts       Export completeness tests
+├── types.ts            Domain entity interfaces
+├── validators.ts       Validation functions
+└── validators.test.ts  Validator unit tests
+```
+
+## Usage
+
+```typescript
+import {
+  BOX_CATALOG,
+  GREENHOUSES,
+  validateAddress,
+  type PlanterBoxPublic,
+} from "@greenspace/shared";
+```
+
+## Scripts
+
+```bash
+npm run build      # Compile TypeScript
+npm run test       # Run Vitest tests
+npm run typecheck  # Type checking
+```


### PR DESCRIPTION
Update all existing READMEs to reflect current implementation state, create docs/README.md index and docs/architecture.md with Mermaid diagrams covering frontend, backend, database, infrastructure, and CI/CD pipeline. Link all READMEs from the root README tree.