### PR TITLE
fix(infra): add SNS and CloudWatch permissions to CI terraform role

### DIFF
--- a/infra/terraform/modules/greenspace_stack/iam.tf
+++ b/infra/terraform/modules/greenspace_stack/iam.tf
@@ -530,6 +530,47 @@ data "aws_iam_policy_document" "ci_terraform_resources" {
   }
 
   statement {
+    sid    = "SNSManage"
+    effect = "Allow"
+    actions = [
+      "sns:CreateTopic",
+      "sns:DeleteTopic",
+      "sns:GetTopicAttributes",
+      "sns:SetTopicAttributes",
+      "sns:TagResource",
+      "sns:UntagResource",
+      "sns:ListTagsForResource",
+      "sns:Subscribe",
+      "sns:Unsubscribe",
+      "sns:GetSubscriptionAttributes",
+    ]
+    resources = [
+      "arn:aws:sns:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:${local.naming_prefix}-*",
+    ]
+  }
+
+  statement {
+    sid    = "CloudWatchAlarms"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:PutMetricAlarm",
+      "cloudwatch:DeleteAlarms",
+      "cloudwatch:DescribeAlarms",
+      "cloudwatch:ListTagsForResource",
+      "cloudwatch:TagResource",
+      "cloudwatch:UntagResource",
+      "cloudwatch:PutDashboard",
+      "cloudwatch:DeleteDashboards",
+      "cloudwatch:GetDashboard",
+      "cloudwatch:ListDashboards",
+    ]
+    resources = [
+      "arn:aws:cloudwatch:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:alarm:${local.naming_prefix}-*",
+      "arn:aws:cloudwatch::${data.aws_caller_identity.current.account_id}:dashboard/${local.naming_prefix}-*",
+    ]
+  }
+
+  statement {
     sid    = "RDSRead"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
## Summary
- Adds `SNSManage` IAM statement granting topic/subscription CRUD permissions scoped to the naming prefix
- Adds `CloudWatchAlarms` IAM statement granting alarm and dashboard CRUD permissions scoped to the naming prefix
- Fixes `terraform plan` 403 errors for staging introduced after #96 added monitoring resources

## Context
The monitoring resources (SNS alarm topic, CloudWatch metric alarms, CloudWatch dashboard) were added in #96 but the `ci_terraform_resources` IAM policy was not updated with the required permissions. This caused the CI terraform plan to fail with:
- `SNS:GetTopicAttributes` authorization error
- `CloudWatch:GetDashboard` access denied

## Test plan
- [ ] `terraform validate` passes locally
- [ ] CI `terraform plan` succeeds for staging after this IAM policy is applied
- [ ] Verify no extraneous permissions granted (all resources scoped to naming prefix)

> **Note:** This is a chicken-and-egg fix — the IAM policy change must be applied before CI can plan successfully. Initial apply may need to be done manually or via a privileged role.