### PR TITLE
fix(infra): allow CI terraform role to update its own inline policies

### DIFF
--- a/infra/terraform/modules/greenspace_stack/iam.tf
+++ b/infra/terraform/modules/greenspace_stack/iam.tf
@@ -361,11 +361,9 @@ data "aws_iam_policy_document" "ci_terraform_resources" {
     actions = [
       "iam:UpdateRole",
       "iam:UpdateAssumeRolePolicy",
-      "iam:PutRolePolicy",
       "iam:AttachRolePolicy",
       "iam:DetachRolePolicy",
       "iam:DeleteRole",
-      "iam:DeleteRolePolicy",
     ]
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.naming_prefix}-ci-terraform",


### PR DESCRIPTION
## Summary

- Remove `iam:PutRolePolicy` and `iam:DeleteRolePolicy` from the `DenySelfModify` deny statement on the CI terraform IAM role
- Fixes terraform apply failures when the `ci_terraform_resources` inline policy changes (the role was blocking itself from updating its own policy)
- The Amplify `TagResource` error was a cascade: the policy granting Amplify permissions could not be applied due to this self-modify block

## Root cause

The `DenySelfModify` statement prevented the CI terraform role from calling `iam:PutRolePolicy` on itself. This worked on initial creation (deny did not exist yet) but broke on any subsequent policy update.

## Security impact

The remaining deny actions still prevent the CI role from:
- Deleting itself (`iam:DeleteRole`)
- Changing its trust policy (`iam:UpdateAssumeRolePolicy`, `iam:UpdateRole`)
- Attaching/detaching managed policies (`iam:AttachRolePolicy`, `iam:DetachRolePolicy`)

Inline policy changes go through PR review in version control.

## Test plan

- [ ] Terraform plan shows only the DenySelfModify statement change (removing 2 actions)
- [ ] Terraform apply succeeds for staging (Amplify app creation + policy update)
- [ ] Verify CI terraform role retains deny on DeleteRole, UpdateAssumeRolePolicy, AttachRolePolicy, DetachRolePolicy

🤖 Generated with [Claude Code](https://claude.com/claude-code)