### PR TITLE
fix(ci): unify terraform concurrency groups to prevent state lock races

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -166,7 +166,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     concurrency:
-      group: terraform-deploy-staging
+      group: terraform-staging
       cancel-in-progress: false
     outputs:
       has_changes: ${{ steps.plan.outputs.has_changes }}
@@ -225,7 +225,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     concurrency:
-      group: terraform-deploy-prod
+      group: terraform-prod
       cancel-in-progress: false
     outputs:
       has_changes: ${{ steps.plan.outputs.has_changes }}
@@ -286,7 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     concurrency:
-      group: terraform-deploy-staging
+      group: terraform-staging
       cancel-in-progress: false
     steps:
       - name: Checkout
@@ -329,7 +329,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     concurrency:
-      group: terraform-deploy-prod
+      group: terraform-prod
       cancel-in-progress: false
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Unify all terraform concurrency groups per environment: `terraform-deploy-staging` → `terraform-staging`, `terraform-deploy-prod` → `terraform-prod`
- Prevents DynamoDB state lock races when `plan-staging` and `detect-staging` (or their prod equivalents) run simultaneously on `workflow_dispatch` from main

## Root Cause
The plan jobs used `terraform-staging`/`terraform-prod` while the detect/apply jobs used `terraform-deploy-staging`/`terraform-deploy-prod`. On `workflow_dispatch` from main, both plan and detect jobs ran in parallel with no shared concurrency group, causing state lock conflicts.

## Test plan
- [ ] Trigger `workflow_dispatch` on main and verify plan/detect jobs serialize correctly per environment
- [ ] Verify PR plans still work (concurrency group serializes but does not block)