### PR TITLE
chore(ci): remove redundant fmt-check job from Terraform workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -22,24 +22,6 @@ env:
   TF_VAR_amplify_github_access_token: ${{ secrets.AMPLIFY_GITHUB_TOKEN }}
 
 jobs:
-  # --------------- Pull Request: format check ---------------
-
-  fmt-check:
-    name: "Format Check"
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: ${{ env.TF_VERSION }}
-
-      - name: Terraform fmt
-        run: terraform fmt -check -recursive infra/terraform
-
   # --------------- Pull Request: plan per environment ---------------
 
   plan-staging:


### PR DESCRIPTION
The Format Check job in the Terraform workflow is redundant with the infra-checks job in CI, which already runs terraform fmt -check on every PR. The required status check has been updated to rely on infra-checks instead.