### PR TITLE
feat(api): automate database migrations in deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,20 @@ jobs:
           aws lambda wait function-active-v2 \
             --function-name "${{ vars.API_FUNCTION_NAME }}"
 
+      - name: Run migrations
+        run: |
+          aws lambda invoke \
+            --function-name "${{ vars.API_FUNCTION_NAME }}" \
+            --payload '{"action":"migrate"}' \
+            --cli-binary-format raw-in-base64-out \
+            /tmp/migrate-response.json
+          cat /tmp/migrate-response.json
+          STATUS=$(jq -r '.statusCode' /tmp/migrate-response.json)
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Migration failed"
+            exit 1
+          fi
+
       - name: Get Function URL
         id: url
         run: |
@@ -126,6 +140,20 @@ jobs:
         run: |
           aws lambda wait function-active-v2 \
             --function-name "${{ vars.API_FUNCTION_NAME }}"
+
+      - name: Run migrations
+        run: |
+          aws lambda invoke \
+            --function-name "${{ vars.API_FUNCTION_NAME }}" \
+            --payload '{"action":"migrate"}' \
+            --cli-binary-format raw-in-base64-out \
+            /tmp/migrate-response.json
+          cat /tmp/migrate-response.json
+          STATUS=$(jq -r '.statusCode' /tmp/migrate-response.json)
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Migration failed"
+            exit 1
+          fi
 
       - name: Get Function URL
         id: url

--- a/apps/api/src/db/migration-registry.ts
+++ b/apps/api/src/db/migration-registry.ts
@@ -1,0 +1,38 @@
+import { Migrator } from "kysely";
+import type { Kysely, Migration, MigrationProvider } from "kysely";
+import type { Database } from "./types.js";
+import * as m001 from "./migrations/001_initial_schema.js";
+
+const migrations: Record<string, Migration> = {
+  "001_initial_schema": m001,
+};
+
+export class InlineMigrationProvider implements MigrationProvider {
+  async getMigrations(): Promise<Record<string, Migration>> {
+    return migrations;
+  }
+}
+
+export function createInlineMigrator(db: Kysely<Database>): Migrator {
+  return new Migrator({
+    db,
+    provider: new InlineMigrationProvider(),
+  });
+}
+
+export async function migrateToLatestInline(
+  db: Kysely<Database>,
+): Promise<{ success: boolean; executedMigrations: string[] }> {
+  const migrator = createInlineMigrator(db);
+  const { error, results } = await migrator.migrateToLatest();
+
+  const executedMigrations = (results ?? [])
+    .filter((r) => r.status === "Success")
+    .map((r) => r.migrationName);
+
+  if (error) {
+    throw error;
+  }
+
+  return { success: true, executedMigrations };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,8 @@
 import { GREENHOUSES } from "@greenspace/shared";
 import { createDatabase } from "./db/connection.js";
+import { migrateToLatestInline } from "./db/migration-registry.js";
+import { seed } from "./db/seed.js";
+import { hashPassword } from "./lib/password.js";
 import { deleteExpiredSessions } from "./lib/session.js";
 import { requireAdmin } from "./middleware/auth.js";
 import { Router } from "./router.js";
@@ -86,12 +89,20 @@ export interface ScheduledEvent {
   detail: Record<string, unknown>;
 }
 
-export type LambdaEvent = LambdaHttpEvent | ScheduledEvent;
+export interface MigrateEvent {
+  action: "migrate";
+}
+
+export type LambdaEvent = LambdaHttpEvent | ScheduledEvent | MigrateEvent;
 
 export interface LambdaResponse {
   statusCode: number;
   headers: Record<string, string>;
   body: string;
+}
+
+function isMigrateEvent(event: LambdaEvent): event is MigrateEvent {
+  return "action" in event && (event as MigrateEvent).action === "migrate";
 }
 
 function isScheduledEvent(event: LambdaEvent): event is ScheduledEvent {
@@ -136,6 +147,27 @@ async function ensureDb(): Promise<ReturnType<typeof createDatabase>> {
 }
 
 export async function handler(event: LambdaEvent): Promise<LambdaResponse> {
+  if (isMigrateEvent(event)) {
+    try {
+      const database = await ensureDb();
+      const { executedMigrations } = await migrateToLatestInline(database);
+      const seedPassword = process.env["SEED_ADMIN_PASSWORD"] ?? "changeme123";
+      await seed(database, hashPassword, seedPassword);
+      return {
+        statusCode: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task: "migrate", executedMigrations, seeded: true }),
+      };
+    } catch (err) {
+      console.error("Migration failed:", err);
+      return {
+        statusCode: 500,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task: "migrate", error: String(err) }),
+      };
+    }
+  }
+
   if (isScheduledEvent(event)) {
     try {
       const database = await ensureDb();

--- a/infra/terraform/modules/greenspace_stack/iam.tf
+++ b/infra/terraform/modules/greenspace_stack/iam.tf
@@ -125,6 +125,7 @@ data "aws_iam_policy_document" "ci_deploy_permissions" {
       "lambda:GetFunction",
       "lambda:GetFunctionUrlConfig",
       "lambda:ListFunctions",
+      "lambda:InvokeFunction",
     ]
     resources = [
       "arn:aws:lambda:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:function:${local.naming_prefix}-*",


### PR DESCRIPTION
## Summary
- Add inline migration provider (`migration-registry.ts`) that works with esbuild single-file bundles, replacing the filesystem-based `FileMigrationProvider` which fails in Lambda
- Add `{"action": "migrate"}` event handler in the Lambda function that runs migrations and seeds
- Add "Run migrations" step to deploy workflow (both staging and prod) that invokes the Lambda after deployment
- Grant `lambda:InvokeFunction` permission to the CI deploy role

## Deployment Note
The IAM change (`lambda:InvokeFunction`) must be deployed via the Terraform workflow **before** the first deploy workflow run that includes the migration step. Otherwise the `aws lambda invoke` call will fail with an access denied error.

## Test plan
- [x] All 220 tests pass
- [x] Lint passes clean
- [x] esbuild bundle succeeds
- [ ] Deploy to staging triggers migration automatically
- [ ] Health check passes after migration
- [ ] Deploy to prod triggers migration automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)