### PR TITLE
fix(api): pass non-HTTP events directly to core handler

### DIFF
--- a/apps/api/src/lambda.ts
+++ b/apps/api/src/lambda.ts
@@ -1,5 +1,5 @@
 import { handler as coreHandler } from "./index.js";
-import type { LambdaResponse } from "./index.js";
+import type { LambdaEvent, LambdaResponse } from "./index.js";
 
 interface FunctionUrlEvent {
   version?: string;
@@ -12,7 +12,19 @@ interface FunctionUrlEvent {
   path?: string;
 }
 
+function isNonHttpEvent(event: unknown): boolean {
+  const e = event as Record<string, unknown>;
+  return (
+    ("action" in e && e.action === "migrate") ||
+    ("detail-type" in e && e["detail-type"] === "Scheduled Event")
+  );
+}
+
 export async function handler(event: FunctionUrlEvent): Promise<LambdaResponse> {
+  if (isNonHttpEvent(event)) {
+    return coreHandler(event as unknown as LambdaEvent);
+  }
+
   return coreHandler({
     httpMethod: event.httpMethod ?? event.requestContext?.http?.method ?? "GET",
     path: event.path ?? event.rawPath ?? "/",


### PR DESCRIPTION
## Summary
- `lambda.ts` was unconditionally converting all events into HTTP-shaped objects before passing to `coreHandler`
- This caused `{"action":"migrate"}` and scheduled events to lose their original properties, falling through to the router and returning 404
- Now detects non-HTTP events (migrate + scheduled) and passes them directly to `coreHandler` unchanged

Fixes staging deploy failure where the "Run migrations" step returned 404.

## Test plan
- [x] All 280 tests pass
- [x] Lint clean
- [x] esbuild bundle succeeds
- [ ] Deploy to staging triggers migration successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)