### PR TITLE
fix(infra): enable PR preview on Amplify main branch

### DIFF
--- a/infra/terraform/modules/greenspace_stack/amplify.tf
+++ b/infra/terraform/modules/greenspace_stack/amplify.tf
@@ -65,7 +65,8 @@ resource "aws_amplify_branch" "main" {
   app_id      = aws_amplify_app.web.id
   branch_name = var.amplify_branch_name
 
-  enable_auto_build = var.amplify_enable_auto_build
+  enable_auto_build           = var.amplify_enable_auto_build
+  enable_pull_request_preview = var.amplify_enable_preview_branches
 
   framework = "Next.js - SSR"
 


### PR DESCRIPTION
## Summary
- Add `enable_pull_request_preview = true` to the `aws_amplify_branch.main` resource
- The previous PR (#162) only set this in `auto_branch_creation_config`, which applies to auto-created branches — not PRs targeting main
- Uses the existing `amplify_enable_preview_branches` variable so it is only enabled in staging

## Test plan
- [ ] Terraform plan shows the branch resource updating with `enable_pull_request_preview`
- [ ] After apply, new PRs show Amplify preview URL as a comment/check

🤖 Generated with [Claude Code](https://claude.com/claude-code)