### PR TITLE
fix(infra): allow SES SendEmail on recipient identities in sandbox

### DIFF
--- a/infra/terraform/modules/greenspace_stack/iam.tf
+++ b/infra/terraform/modules/greenspace_stack/iam.tf
@@ -67,7 +67,10 @@ data "aws_iam_policy_document" "api_ses" {
       "ses:SendEmail",
       "ses:SendRawEmail",
     ]
-    resources = [aws_ses_domain_identity.main.arn]
+    resources = [
+      aws_ses_domain_identity.main.arn,
+      "arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/*",
+    ]
   }
 }
 


### PR DESCRIPTION
## Summary\n\n- Add scoped wildcard identity resource to SES IAM policy so Lambda can send to any verified recipient\n- In SES sandbox mode, IAM must authorize `ses:SendEmail` on both the sender domain identity AND recipient email identities\n- Without this, every send fails with `AccessDenied` on `arn:aws:ses:...:identity/<recipient-email>`\n- The wildcard is scoped to the current account/region: `arn:aws:ses:<region>:<account>:identity/*`\n\nRelated to #190\n\n## Test plan\n\n- [ ] Terraform plan shows only IAM policy change\n- [ ] Deploy to staging\n- [ ] Verify email sends successfully to verified recipient\n- [ ] Existing iam.tftest.hcl scoping test still passes (checks for bare `*`, not ARN patterns)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)