### PR TITLE
fix(infra): add CI workflow to deploy web frontend to production

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -20,6 +20,7 @@ jobs:
   deploy-web-prod:
     name: Deploy Web (prod)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: production
     concurrency:
       group: deploy-web-prod


### PR DESCRIPTION
## Summary
- Production Amplify has `amplify_enable_auto_build = false`, so pushes to main never triggered a frontend build (unlike staging which auto-builds)
- Adds a new `deploy-web.yml` workflow that triggers `aws amplify start-job` for production when `apps/web/**` or `packages/shared/**` change
- Gated behind the `production` GitHub environment for approval control
- Uses the existing CI deploy role which already has `amplify:StartJob` permission

## Setup required
Set the `AMPLIFY_APP_ID` variable in the GitHub `production` environment:
```
terraform -chdir=infra/terraform/environments/prod output amplify_app_id
gh variable set AMPLIFY_APP_ID --env production --body "<app-id>"
```

## Test plan
- [ ] Set `AMPLIFY_APP_ID` variable in GitHub production environment
- [ ] Trigger workflow manually via `workflow_dispatch` and verify Amplify build starts
- [ ] Verify build completes successfully and production site updates
- [ ] Push a web change to main and confirm the workflow triggers automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)