### PR TITLE
fix(infra): gate production web deploy on staging success

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -17,8 +17,51 @@ env:
   AWS_REGION: "eu-north-1"
 
 jobs:
+  deploy-web-staging:
+    name: Deploy Web (staging)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: staging
+    concurrency:
+      group: deploy-web-staging
+      cancel-in-progress: false
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.DEPLOY_ROLE_ARN_STAGING }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Start Amplify build
+        id: start-build
+        run: |
+          JOB=$(aws amplify start-job \
+            --app-id "${{ vars.AMPLIFY_APP_ID }}" \
+            --branch-name main \
+            --job-type RELEASE \
+            --query 'jobSummary.jobId' --output text)
+          echo "job_id=$JOB" >> "$GITHUB_OUTPUT"
+          echo "Started Amplify job: $JOB"
+
+      - name: Wait for Amplify build
+        run: |
+          while true; do
+            STATUS=$(aws amplify get-job \
+              --app-id "${{ vars.AMPLIFY_APP_ID }}" \
+              --branch-name main \
+              --job-id "${{ steps.start-build.outputs.job_id }}" \
+              --query 'job.summary.status' --output text)
+            echo "Build status: $STATUS"
+            case "$STATUS" in
+              SUCCEED) echo "Build succeeded"; exit 0 ;;
+              FAILED|CANCELLING|CANCELLED) echo "::error::Build $STATUS"; exit 1 ;;
+              *) sleep 30 ;;
+            esac
+          done
+
   deploy-web-prod:
     name: Deploy Web (prod)
+    needs: deploy-web-staging
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -64,7 +64,7 @@ module "greenspace_stack" {
 
   amplify_github_access_token     = var.amplify_github_access_token
   amplify_branch_name             = "main"
-  amplify_enable_auto_build       = true
+  amplify_enable_auto_build       = false
   amplify_domain_prefix           = "greenspace"
   amplify_enable_preview_branches = true
   amplify_preview_branch_patterns = ["**"]


### PR DESCRIPTION
## Summary
- Adds a staging Amplify deploy step to `deploy-web.yml` that runs before production
- Production deploy is now gated on staging succeeding (`needs: deploy-web-staging`)
- Disables Amplify auto-build for staging (`amplify_enable_auto_build = false`) so both environments use the same CI-triggered deploy path
- Follows the same staging-then-production pattern as `deploy.yml` for the API

## Setup required
Set `AMPLIFY_APP_ID` in the GitHub **staging** environment:

    terraform -chdir=infra/terraform/environments/staging output amplify_app_id
    gh variable set AMPLIFY_APP_ID --env staging --body "<app-id>"

After merging, run `terraform apply` in the staging environment to disable Amplify auto-build.

## Test plan
- [ ] Set `AMPLIFY_APP_ID` variable in GitHub staging environment
- [ ] Trigger workflow manually via `workflow_dispatch` and verify staging Amplify build starts
- [ ] Verify production build only starts after staging succeeds
- [ ] Run `terraform apply` in staging to disable auto-build
- [ ] Push a web change to main and confirm both environments deploy in sequence
