### PR TITLE
feat: visual refresh for box cards with status banners and images

### DIFF
--- a/apps/web/src/components/BoxCard.tsx
+++ b/apps/web/src/components/BoxCard.tsx
@@ -68,7 +68,15 @@ export function BoxCard({ name, state, onClick }: BoxCardProps) {
           e.currentTarget.style.display = "none";
         }}
       />
-      <span style={{ fontSize: "0.85rem", color: themeColors.warmBrown, paddingBottom: "0.5rem" }}>{name}</span>
+      <span
+        style={{
+          fontSize: "0.85rem",
+          color: themeColors.warmBrown,
+          paddingBottom: "0.5rem",
+        }}
+      >
+        {name}
+      </span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Replace hand-drawn box card sketches with per-box PNG images
- Restyle box cards: colored status banner across the top, light #fdfdfd card background
- Remove opacity dimming on occupied/reserved boxes for clearer presentation

## Test plan
- [ ] Verify box cards render with colored banner at top (green/available, orange/occupied, blue/reserved)
- [ ] Verify card body background is light (#fdfdfd) matching image backgrounds
- [ ] Verify box images display correctly for each box name
- [ ] Verify available boxes remain clickable, others remain disabled
- [ ] Check responsive grid layout still works at various widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)