### PR TITLE
fix(infra): grant CI role EIP Associate/Disassociate

### DIFF
--- a/infra/terraform/modules/greenspace_stack/iam.tf
+++ b/infra/terraform/modules/greenspace_stack/iam.tf
@@ -301,6 +301,8 @@ data "aws_iam_policy_document" "ci_terraform_resources" {
       "ec2:DescribePrefixLists",
       "ec2:AllocateAddress",
       "ec2:ReleaseAddress",
+      "ec2:AssociateAddress",
+      "ec2:DisassociateAddress",
       "ec2:DescribeAddresses",
       "ec2:DescribeAddressesAttribute",
       "ec2:CreateRouteTable",


### PR DESCRIPTION
## Summary

- Adds `ec2:AssociateAddress` and `ec2:DisassociateAddress` to the `VPCNetworking` statement in `data "aws_iam_policy_document" "ci_terraform_resources"` (`infra/terraform/modules/greenspace_stack/iam.tf`).

## Why

Prod terraform apply on `main` after #326 failed with two errors ([run 25273229909](https://github.com/ammonlarson/greenspace/actions/runs/25273229909)):

```
Error: disassociating EC2 EIP (eipassoc-091726be103bbbbab):
  api error UnauthorizedOperation: ... ec2:DisassociateAddress is not authorized

Error: creating EC2 VPC Endpoint (com.amazonaws.eu-north-1.email): ec2:CreateVpcEndpoint is not authorized
Error: creating EC2 VPC Endpoint (com.amazonaws.eu-north-1.secretsmanager): ec2:CreateVpcEndpoint is not authorized
```

Two distinct issues, only one fixable by code:

1. **`DisassociateAddress` (this PR fixes):** Terraform's `aws_eip` destroy calls Disassociate then Release. Our policy had Release but not Disassociate. Same gap loppemarked #179 hit. Adding `AssociateAddress` for symmetry / future re-creates.
2. **`CreateVpcEndpoint` (transient — no code fix):** The policy modify ran cleanly at `07:37:13.566`; the create call at `07:37:16.288` was denied. Three-second IAM session-policy propagation lag. The bootstrap below also covers this so the next apply doesn't re-trip on it.

## ⚠️ Prod is currently degraded

The half-applied state means:

- ❌ EIP `eipalloc-01dd4762ae25992e4` not released (still allocated and billing).
- ❌ VPC endpoints not created.
- ❌ Prod Lambda has no path to SES or Secrets Manager — `SendEmail` and `GetSecretValue` will fail.

## Bootstrap step (manual, required to unblock prod)

Before re-running Apply (prod), put a temporary bootstrap policy on the prod CI role. The bootstrap covers both `Disassociate/Associate` (so apply can self-update the policy with this PR) and `CreateVpcEndpoint` (so any further IAM-consistency lag on retry doesn't re-block):

```bash
cat > /tmp/prod-unblock.json <<'JSON'
{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["ec2:DisassociateAddress","ec2:AssociateAddress","ec2:CreateVpcEndpoint"],"Resource":"*"}]}
JSON

aws iam put-role-policy \
  --role-name greenspace-prod-2026-ci-terraform \
  --policy-name terraform-resources-bootstrap \
  --policy-document file:///tmp/prod-unblock.json
```

Then re-run **Apply (prod)** in the Terraform workflow (workflow_dispatch on `main`, or merge this PR which will trigger it automatically).

After it succeeds, clean up:

```bash
aws iam delete-role-policy \
  --role-name greenspace-prod-2026-ci-terraform \
  --policy-name terraform-resources-bootstrap

aws iam list-role-policies --role-name greenspace-prod-2026-ci-terraform
# Should show only terraform-resources and terraform-state.
```

## Out of scope

- Sweeping unused NAT Gateway perms — tracked in #327.
- A general fix for the bootstrap-dance pattern — third occurrence of this family. Worth a longer-term solution but not now.

## Closes

Closes #328. Follow-up to #324 / #326.

## Test plan

- [x] `terraform fmt -check -recursive infra/terraform`
- [x] `terraform -chdir=infra/terraform/environments/staging validate`
- [x] `terraform -chdir=infra/terraform/environments/prod validate`
- [ ] Bootstrap policy applied to `greenspace-prod-2026-ci-terraform`
- [ ] Apply (prod) succeeds: orphan EIP releases, SES + Secrets Manager VPC endpoints create, `terraform-resources` policy reconverges with the two new actions
- [ ] Bootstrap policy removed
- [ ] `aws iam list-role-policies` confirms only `terraform-resources` + `terraform-state` remain
- [ ] Smoke check: prod Lambda can call SES `SendEmail` and Secrets Manager `GetSecretValue`
