### PR TITLE
refactor(infra): attach CI Terraform inline policies from the guard map

### DIFF
--- a/infra/terraform/modules/greenspace_stack/README.md
+++ b/infra/terraform/modules/greenspace_stack/README.md
@@ -232,10 +232,11 @@ the resource that needs it.
 
 Four properties of these guards are worth keeping if they are ever rewritten:
 
-- They read **all three inline policies**, via `local.ci_terraform_granted_actions`
-  in `iam.tf`, because IAM unions them — and because `terraform-state` carries no
-  shape guard of its own, so a guard reading only `terraform-resources` passes on
-  anything hidden there.
+- They read **every inline policy the role has**, via
+  `local.ci_terraform_granted_actions` in `iam.tf`, which is derived from the
+  same map the policies are attached from — because IAM unions them, and because
+  `terraform-state` carries no shape guard of its own, so a guard reading only
+  `terraform-resources` passes on anything hidden there.
 - They tolerate the two shapes `aws_iam_policy_document` actually produces: a
   single-element `Action` renders as a bare string rather than a list, and an
   explicit `Deny` (`DenySelfModify`) must not trip a guard on what may be
@@ -248,14 +249,19 @@ Four properties of these guards are worth keeping if they are ever rewritten:
   fails. `ci_terraform_role_keeps_the_shared_network_ssm_read` covers the grant
   currently in that position.
 
-**Known gap.** `local.ci_terraform_granted_actions` names its three policy
-documents literally, so it is only the role's full surface for as long as the
-role has exactly those three inline policies. A fourth `aws_iam_role_policy` — or
-any `aws_iam_role_policy_attachment` — is invisible to every guard above,
-verifiably so: attaching one that grants a bare `*` leaves the suite green.
-Closing it properly means attaching the policies with `for_each` over the same
-map the guards read, so adding one without guarding it becomes impossible. That
-is a state-address change needing `moved` blocks, tracked separately.
+The guard source and the attachment source are the same object: the role's
+inline policies are attached with `for_each` over `local.ci_terraform_policies`
+in `iam.tf`, and `ci_terraform_granted_actions` is derived from the same map.
+Adding a policy to the role means adding a map entry, and the guards see that
+entry in the same plan — there is no second policy list to keep in sync.
+
+One boundary remains, and it is structural: HCL cannot enumerate "every policy
+resource pointing at this role", so a grant that reaches the role without going
+through the map stays invisible to the guards. That is a standalone
+`aws_iam_role_policy` resource declared outside the `for_each`, or an
+`aws_iam_role_policy_attachment` (managed policy — the role carries none
+today). Either bypass takes a new resource block that has no business in
+`iam.tf`, which review can see; treat adding one as a change to the guards too.
 
 ## SES email configuration
 

--- a/infra/terraform/modules/greenspace_stack/README.md
+++ b/infra/terraform/modules/greenspace_stack/README.md
@@ -176,13 +176,14 @@ that CMK subset became unreadable when `kms:Decrypt` went. The path scoping on
 the bootstrap policy's `SharedNetworkSsmRead` statement is what prevents the
 rest, and it does not depend on any KMS grant.
 
-`log_encryption.tftest.hcl` and `iam.tftest.hcl` guard this across **all three**
-inline policies on the role — `terraform-state`, `terraform-resources`, and
-`terraform-resources-bootstrap` — because IAM unions them, so a guard that reads
-one document proves nothing about the role. They share a single definition of the
-role's granted surface (`local.ci_terraform_granted_actions` in `iam.tf`), which
-exists because the first version of these guards hand-copied the expression and
-ended up checking one document while its error message spoke for the role.
+`log_encryption.tftest.hcl` and `iam.tftest.hcl` guard this across **every
+inline policy on the role**, derived from the same `local.ci_terraform_policies`
+map the policies are attached from — because IAM unions them, so a guard that
+reads one document proves nothing about the role. They share a single definition
+of the role's granted surface (`local.ci_terraform_granted_actions` in
+`iam.tf`), which exists because the first version of these guards hand-copied
+the expression and ended up checking one document while its error message spoke
+for the role.
 
 The SNS alarm topic sets no `kms_master_key_id` and is therefore **unencrypted
 at rest**. This is deliberate, and `alias/aws/sns` is specifically not the fix.
@@ -260,8 +261,10 @@ resource pointing at this role", so a grant that reaches the role without going
 through the map stays invisible to the guards. That is a standalone
 `aws_iam_role_policy` resource declared outside the `for_each`, or an
 `aws_iam_role_policy_attachment` (managed policy — the role carries none
-today). Either bypass takes a new resource block that has no business in
-`iam.tf`, which review can see; treat adding one as a change to the guards too.
+today). The signal to review for is a policy resource whose `role` references
+`aws_iam_role.ci_terraform` from outside the map — not the resource type, since
+`iam.tf` legitimately carries standalone policies for the other roles. Treat
+adding one as a change to the guards too.
 
 ## SES email configuration
 

--- a/infra/terraform/modules/greenspace_stack/iam.tf
+++ b/infra/terraform/modules/greenspace_stack/iam.tf
@@ -257,12 +257,6 @@ data "aws_iam_policy_document" "ci_terraform_state" {
   }
 }
 
-resource "aws_iam_role_policy" "ci_terraform_state" {
-  name   = "terraform-state"
-  role   = aws_iam_role.ci_terraform.id
-  policy = data.aws_iam_policy_document.ci_terraform_state.json
-}
-
 data "aws_iam_policy_document" "ci_terraform_resources" {
   # The API Lambda runs in the shared default VPC, whose id and private subnet
   # ids the environment roots read from SSM. The only network resource this
@@ -634,12 +628,6 @@ data "aws_iam_policy_document" "ci_terraform_resources" {
   }
 }
 
-resource "aws_iam_role_policy" "ci_terraform_resources" {
-  name   = "terraform-resources"
-  role   = aws_iam_role.ci_terraform.id
-  policy = data.aws_iam_policy_document.ci_terraform_resources.json
-}
-
 # ---------- CI Terraform Bootstrap Policy ----------
 #
 # Permanent companion to `terraform-resources` whose sole purpose is to break
@@ -789,18 +777,19 @@ data "aws_iam_policy_document" "ci_terraform_bootstrap" {
   }
 }
 
-resource "aws_iam_role_policy" "ci_terraform_bootstrap" {
-  name   = "terraform-resources-bootstrap"
-  role   = aws_iam_role.ci_terraform.id
-  policy = data.aws_iam_policy_document.ci_terraform_bootstrap.json
-}
-
-# ---------- CI Terraform role: granted-action surface ----------
+# ---------- CI Terraform role: inline policies + granted-action surface ----------
 #
-# Every action the CI Terraform role is allowed, unioned across all three of its
-# inline policies. IAM evaluates them together, so this — not any one document —
-# is the role's real permission surface, and it is what the grant guards in
-# `iam.tftest.hcl` and `log_encryption.tftest.hcl` assert against.
+# The map below is both the attachment source (the `for_each` on
+# `aws_iam_role_policy.ci_terraform`) and the guard source
+# (`ci_terraform_granted_actions`), so adding a policy to the role means adding
+# a map entry, and a map entry is attached and guarded by the same expression.
+# There is no second copy of the policy list to fall out of sync.
+#
+# `ci_terraform_granted_actions` is every action the CI Terraform role is
+# allowed, unioned across all of its inline policies. IAM evaluates them
+# together, so this — not any one document — is the role's real permission
+# surface, and it is what the grant guards in `iam.tftest.hcl` and
+# `log_encryption.tftest.hcl` assert against.
 #
 # It lives here rather than in each test because `.tftest.hcl` files take no
 # `locals` block, and hand-copying this expression into every assertion is how a
@@ -809,16 +798,53 @@ resource "aws_iam_role_policy" "ci_terraform_bootstrap" {
 # reporting on "the CI Terraform role", so the very grants they existed to reject
 # passed when added to `terraform-state`. One definition, one surface.
 #
+# The guards read this map and nothing else, so a grant that reaches the role
+# without going through it stays invisible to them: a standalone
+# `aws_iam_role_policy` resource declared alongside this one, or an
+# `aws_iam_role_policy_attachment` (managed policy — the role carries none).
+# HCL has no way to enumerate "every policy resource pointing at this role", so
+# that boundary is structural. What the map buys is that the one in-pattern way
+# to add a policy is guarded by construction; either bypass takes a new resource
+# block that has no business in this file, which review can see.
+#
 # Two details are load-bearing. `flatten([s.Action])` because
 # `aws_iam_policy_document` renders a single-element `Action` as a bare string
 # rather than a list. And `s.Effect == "Allow"`, because a guard on what the role
 # may be *granted* must not trip over an explicit deny (`DenySelfModify`).
 locals {
+  ci_terraform_policies = {
+    "terraform-state"               = data.aws_iam_policy_document.ci_terraform_state.json
+    "terraform-resources"           = data.aws_iam_policy_document.ci_terraform_resources.json
+    "terraform-resources-bootstrap" = data.aws_iam_policy_document.ci_terraform_bootstrap.json
+  }
+
   ci_terraform_granted_actions = toset(flatten([
-    for doc in [
-      data.aws_iam_policy_document.ci_terraform_state.json,
-      data.aws_iam_policy_document.ci_terraform_resources.json,
-      data.aws_iam_policy_document.ci_terraform_bootstrap.json,
-    ] : [for s in jsondecode(doc).Statement : flatten([s.Action]) if s.Effect == "Allow"]
+    for doc in values(local.ci_terraform_policies) :
+    [for s in jsondecode(doc).Statement : flatten([s.Action]) if s.Effect == "Allow"]
   ]))
+}
+
+# `name = each.key` keeps the live policy names exactly as the three standalone
+# resources set them, so this is a state-address change only — the `moved`
+# blocks below carry the existing entries across, and nothing changes on AWS.
+resource "aws_iam_role_policy" "ci_terraform" {
+  for_each = local.ci_terraform_policies
+  name     = each.key
+  role     = aws_iam_role.ci_terraform.id
+  policy   = each.value
+}
+
+moved {
+  from = aws_iam_role_policy.ci_terraform_state
+  to   = aws_iam_role_policy.ci_terraform["terraform-state"]
+}
+
+moved {
+  from = aws_iam_role_policy.ci_terraform_resources
+  to   = aws_iam_role_policy.ci_terraform["terraform-resources"]
+}
+
+moved {
+  from = aws_iam_role_policy.ci_terraform_bootstrap
+  to   = aws_iam_role_policy.ci_terraform["terraform-resources-bootstrap"]
 }

--- a/infra/terraform/modules/greenspace_stack/iam.tf
+++ b/infra/terraform/modules/greenspace_stack/iam.tf
@@ -799,13 +799,13 @@ data "aws_iam_policy_document" "ci_terraform_bootstrap" {
 # passed when added to `terraform-state`. One definition, one surface.
 #
 # The guards read this map and nothing else, so a grant that reaches the role
-# without going through it stays invisible to them: a standalone
-# `aws_iam_role_policy` resource declared alongside this one, or an
-# `aws_iam_role_policy_attachment` (managed policy — the role carries none).
-# HCL has no way to enumerate "every policy resource pointing at this role", so
-# that boundary is structural. What the map buys is that the one in-pattern way
-# to add a policy is guarded by construction; either bypass takes a new resource
-# block that has no business in this file, which review can see.
+# without going through it stays invisible to them: a policy resource pointing
+# at `aws_iam_role.ci_terraform` from outside the `for_each`, whether a
+# standalone `aws_iam_role_policy` or an `aws_iam_role_policy_attachment`
+# (managed policy; the role carries none). The signal to review for is the role
+# reference, not the resource type — this file legitimately carries standalone
+# policies for the other roles. The module README's *Least-privilege IAM*
+# section is the full discussion of this boundary.
 #
 # Two details are load-bearing. `flatten([s.Action])` because
 # `aws_iam_policy_document` renders a single-element `Action` as a bare string
@@ -834,6 +834,9 @@ resource "aws_iam_role_policy" "ci_terraform" {
   policy   = each.value
 }
 
+# Both environment roots consume this module by local path, so each picks these
+# moves up on its next apply; once both have applied them the blocks are inert
+# and can be deleted.
 moved {
   from = aws_iam_role_policy.ci_terraform_state
   to   = aws_iam_role_policy.ci_terraform["terraform-state"]

--- a/infra/terraform/modules/greenspace_stack/iam.tftest.hcl
+++ b/infra/terraform/modules/greenspace_stack/iam.tftest.hcl
@@ -73,9 +73,10 @@ run "ec2_grants_limited_to_the_security_group" {
   # group: `Describe*`/`Get*` are its plan-refresh reads, and the address and tag
   # actions are its curated destroy-side writes. They are listed because this
   # reads the role's whole granted surface (`local.ci_terraform_granted_actions`,
-  # defined in `iam.tf`) and not one policy document — IAM unions the three, so a
-  # guard that read only `ci_terraform_resources` would pass on `ec2:` grants
-  # added to `terraform-state`, which carries no shape guard of its own.
+  # defined in `iam.tf`) and not one policy document — IAM unions every policy
+  # on the role, so a guard that read only `ci_terraform_resources` would pass
+  # on `ec2:` grants added to `terraform-state`, which carries no shape guard of
+  # its own.
   assert {
     condition = length(setsubtract(
       toset([for a in local.ci_terraform_granted_actions : a if startswith(a, "ec2:")]),
@@ -149,6 +150,32 @@ run "ci_terraform_role_keeps_the_shared_network_ssm_read" {
       local.ci_terraform_granted_actions
     )) == 0
     error_message = "The CI Terraform role must keep ssm:GetParameter and ssm:GetParameters. Both environment roots read /shared/network/vpc-id and /shared/network/private-subnet-ids via data.aws_ssm_parameter on every plan, so dropping either action fails terraform plan in both environments — and the role cannot grant it back to itself. Remove this only alongside the last data source that reads SSM."
+  }
+}
+
+# The keys of `local.ci_terraform_policies` are AWS-facing identifiers, not
+# internal labels: `aws_iam_role_policy.ci_terraform` sets `name = each.key`, so
+# editing a key plans a DeleteRolePolicy + PutRolePolicy on the CI role.
+# `DenySelfModify` does not deny that pair — it is what lets these applies work
+# at all — so an apply that dies between the delete and the put of
+# `terraform-resources` leaves the role unable to restore itself, and recovery
+# is the out-of-band `put-role-policy` in `iam.tf`. Two consumers also depend on
+# the literal names: the `Validate bootstrap policy` job in
+# `drift-detection.yml` fetches `terraform-resources-bootstrap` by name and
+# would fail with NoSuchEntity, and the two-phase note in `iam.tf` warns
+# operators against reusing that name for temporary grants. Widen this list
+# deliberately when adding a policy; rename an existing key only with the same
+# care as deleting and recreating the policy it names.
+run "ci_terraform_policy_names_are_pinned" {
+  command = plan
+
+  assert {
+    condition = toset(keys(local.ci_terraform_policies)) == toset([
+      "terraform-state",
+      "terraform-resources",
+      "terraform-resources-bootstrap",
+    ])
+    error_message = "The CI Terraform role's inline policy names changed. These keys are live AWS policy names (name = each.key): a rename plans a delete-and-recreate of the policy on the role — mid-apply failure on terraform-resources is the lockout scenario in iam.tf's two-phase note — and drift-detection.yml fetches terraform-resources-bootstrap by name. Add new names here deliberately; rename existing ones only with an out-of-band recovery path ready."
   }
 }
 

--- a/infra/terraform/modules/greenspace_stack/log_encryption.tftest.hcl
+++ b/infra/terraform/modules/greenspace_stack/log_encryption.tftest.hcl
@@ -85,7 +85,8 @@ run "api_log_group_uses_default_encryption" {
 # other test in this module would notice.
 #
 # Both read `local.ci_terraform_granted_actions` — every action the role holds
-# across all three of its inline policies, defined once in `iam.tf`. A guard that
+# across all of its inline policies, defined once in `iam.tf` from the same map
+# the policies are attached from. A guard that
 # read a single policy document would prove nothing about the role, since IAM
 # unions them. They also rely on `ci_terraform_role_grants_no_service_wide_wildcard`
 # in `iam.tftest.hcl` to reject `*` and `service:*`, which would otherwise confer


### PR DESCRIPTION
> [!IMPORTANT]
> **Before merging, read the `Plan (staging)` and `Plan (prod)` artifacts** and confirm all three `aws_iam_role_policy` addresses show as **moves** — `aws_iam_role_policy.ci_terraform_state` → `ci_terraform["terraform-state"]`, `ci_terraform_resources` → `ci_terraform["terraform-resources"]`, `ci_terraform_bootstrap` → `ci_terraform["terraform-resources-bootstrap"]` — with **no destroy/create and no diff**. A wrong move would plan a destroy-and-recreate of an inline policy on the CI Terraform role mid-apply, which is the lockout scenario `iam.tf`'s two-phase note exists for. Do not merge on a green suite alone.
>
> Status: verified for commit 0cd3285 — both plan job logs show three pure moves, `Plan: 0 to add, 0 to change, 0 to destroy.` Re-verify on the final commit's plans before merging.

## What Changed

- `local.ci_terraform_granted_actions` no longer enumerates the role's three inline policy documents literally. A new `local.ci_terraform_policies` map (live policy name → document JSON) is now both the attachment source and the guard source: a single `aws_iam_role_policy.ci_terraform` attaches the policies with `for_each` over the map, and the granted-action surface is derived from `values()` of the same map. Adding a policy the in-pattern way now enters the guarded surface in the same expression that attaches it.
- `name = each.key` preserves the live AWS policy names (`terraform-state`, `terraform-resources`, `terraform-resources-bootstrap`) exactly — no AWS-side change.
- Three `moved` blocks carry the existing state entries to their new indexed addresses (same pattern as `networking.tf` / `monitoring.tf`), with a note that they are inert and deletable once both roots have applied them.
- New guard `ci_terraform_policy_names_are_pinned` in `iam.tftest.hcl`: the map keys are AWS-facing (`name = each.key`), so a rename plans a delete-and-recreate of an inline policy on the CI role — a mid-apply failure on `terraform-resources` is a lockout — and `drift-detection.yml` fetches `terraform-resources-bootstrap` by name. The assert pins the key set to the three known names.
- Module README: the *Least-privilege IAM* "Known gap" paragraph is replaced with the restored claim that the guard source and attachment source are the same object, plus an explicit statement of the remaining boundary (see Risks below). The Log encryption section's own literal enumeration of the three policy names, and two stale "three inline policies" counts in the test files' comments, are rewritten to point at the map.

## Issue

Closes #512

## Spec Mapping

- Spec section(s): N/A — infrastructure hardening, no product-spec surface.
- Acceptance criteria covered: N/A (ticket work items; see Validation).

## Non-Goals

- No change to any policy's contents, names, or the existing guards' assertions — the wiring changes; the surface does not.
- `infra/terraform/README.md`'s "two managed inline policies" table (it omits `terraform-state`) is pre-existing staleness, untouched here.
- Guarding `aws_iam_role_policy_attachment` (managed policies) — the role has none; the boundary is now documented instead.

## Validation

- [x] `npm test` — 270 passed across 20 files (unaffected by the change, run per template)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `terraform fmt -check -recursive` (if infra changed) — clean
- [x] `terraform validate` — module plus both environment roots (`staging`, `prod`) valid
- [x] `terraform test` — 14 passed, 0 failed on the clean tree (13 pre-existing + the new name-pinning guard)

Ticket work items verified:

- **Fourth-policy repro, in-pattern** (the wildcard document added as a map entry): the suite **fails 3 guards** — `ci_terraform_role_grants_no_service_wide_wildcard`, `ec2_grants_limited_to_the_security_group`, and `ci_terraform_role_holds_no_kms_key_grants`. Before this change the same grants left the suite green.
- **Plan artifacts read** for 0cd3285: both `Plan (staging)` and `Plan (prod)` job logs show all three `has moved to` entries and `Plan: 0 to add, 0 to change, 0 to destroy.`
- **`drift-detection.yml` `validate-bootstrap-policy`**: confirmed unaffected — it fetches via `aws iam get-role-policy --role-name … --policy-name terraform-resources-bootstrap`, and both names are unchanged. The new name-pinning guard is the durable form of that confirmation.

If any item is N/A, explain why: Spec Mapping is N/A as above; everything else ran.

## Risks / Follow-ups

- **Plan-artifact check on the final commit** (see the note at the top) — the change is safe if and only if the plans show three pure moves.
- **Honest limitation:** the ticket's *literal* repro — a standalone `aws_iam_role_policy` resource declared outside the map — still leaves the suite green, and structurally must: HCL cannot enumerate "every policy resource pointing at a role", so no guard expression can see a resource that bypasses the map. The same holds for `aws_iam_role_policy_attachment`, as the ticket's own Note anticipated. What this change buys is that the one in-pattern way to add a policy is guarded by construction; the review signal for a bypass is a policy resource referencing `aws_iam_role.ci_terraform` from outside the map (not the resource type — `iam.tf` legitimately carries standalone policies for other roles). The module README documents this boundary in place of the "Known gap" paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiX9F3KNSZEY9mB5Mnbqcg